### PR TITLE
custom unmarshaller due to error

### DIFF
--- a/schema/model.go
+++ b/schema/model.go
@@ -113,8 +113,8 @@ func (c *Column) UnmarshalYAML(node *yaml.Node) error {
 		case "nullable":
 			c.Nullable = value.Value == "true"
 		case "default":
-			// c.Default = Literal(value.Value)
-			c.Default = nil // TODO: fix this
+			// this fixes issue where Literal is not unmarshalled correctly
+			c.Default = parseLiteral(value.Value)
 		case "comment":
 			c.Comment = value.Value
 		}

--- a/schema/model.go
+++ b/schema/model.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"fmt"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -101,6 +103,7 @@ func (c *Column) MarshalYAML() (any, error) {
 
 // UnmarshalYAML fixes issue where Literal is not unmarshalled correctly.
 func (c *Column) UnmarshalYAML(node *yaml.Node) error {
+	fmt.Println("!!! testing unmarshal")
 	return node.Decode(c)
 }
 

--- a/schema/model.go
+++ b/schema/model.go
@@ -99,6 +99,11 @@ func (c *Column) MarshalYAML() (any, error) {
 	return &n, nil
 }
 
+// UnmarshalYAML fixes issue where Literal is not unmarshalled correctly.
+func (c *Column) UnmarshalYAML(node *yaml.Node) error {
+	return node.Decode(c)
+}
+
 func (i *Index) MarshalYAML() (any, error) {
 	// get Indices to appear with flow style
 	type flat Index

--- a/schema/model.go
+++ b/schema/model.go
@@ -1,8 +1,6 @@
 package schema
 
 import (
-	"fmt"
-
 	"gopkg.in/yaml.v3"
 )
 
@@ -103,8 +101,25 @@ func (c *Column) MarshalYAML() (any, error) {
 
 // UnmarshalYAML fixes issue where Literal is not unmarshalled correctly.
 func (c *Column) UnmarshalYAML(node *yaml.Node) error {
-	fmt.Println("!!! testing unmarshal")
-	return node.Decode(c)
+	// iterate over all fields and unmarshal them
+	for i := 0; i < len(node.Content); i += 2 {
+		key := node.Content[i].Value
+		value := node.Content[i+1]
+		switch key {
+		case "name":
+			c.Name = value.Value
+		case "type":
+			c.Type = ColumnType(value.Value)
+		case "nullable":
+			c.Nullable = value.Value == "true"
+		case "default":
+			// c.Default = Literal(value.Value)
+			c.Default = nil // TODO: fix this
+		case "comment":
+			c.Comment = value.Value
+		}
+	}
+	return nil
 }
 
 func (i *Index) MarshalYAML() (any, error) {


### PR DESCRIPTION
The default yaml unmarshaller panics due to strings not being able to be converted to literals by default. So instead the value is going to have to be set manually (probably use some sort of reflection checker)